### PR TITLE
fix: réduire les logs Redis en fallback

### DIFF
--- a/JiraVision/tests/test_coverage_remaining.py
+++ b/JiraVision/tests/test_coverage_remaining.py
@@ -59,6 +59,8 @@ def test_settings_validators_raise_on_invalid():
 
 
 def test_get_session_handles_invalid_json_and_refresh_ttl(monkeypatch):
+    core_redis._redis_available = True
+    core_redis._redis_warned = False
     # invalid json -> returns None
     monkeypatch.setattr(
         core_redis,


### PR DESCRIPTION
## Contexte\nLes logs Redis se répétaient en mode fallback.\n\n## Changements\n- Détection d’indisponibilité Redis via ping et bascule en mémoire locale une seule fois\n- Désactivation des retries Redis tant que l’indisponibilité persiste\n- Tests mis à jour pour couvrir le nouveau comportement\n\n## Tests\n- pytest\n\n## Issue\n- Closes #17