### PR TITLE
fix: load JiraVision .env from root

### DIFF
--- a/JiraVision/app/app/core/config.py
+++ b/JiraVision/app/app/core/config.py
@@ -1,10 +1,14 @@
 from pydantic_settings import BaseSettings, SettingsConfigDict
+from pathlib import Path
 from pydantic import field_validator
 from typing import Any, Literal
 
 
+BASE_DIR = Path(__file__).resolve().parents[3]
+
+
 class Settings(BaseSettings):
-    model_config = SettingsConfigDict(env_file=".env", extra="ignore")
+    model_config = SettingsConfigDict(env_file=str(BASE_DIR / ".env"), extra="ignore")
 
     atlassian_client_id: str
     atlassian_client_secret: str


### PR DESCRIPTION
## Contexte\nErreur Atlassian unauthorized_client due à redirect_uri locale quand l’app est lancée depuis la racine.\n\n## Changements\n- Chargement du .env via chemin absolu JiraVision\n\n## Tests\n- smoke: lecture de settings.atlassian_redirect_uri depuis la racine\n\n## Issue\n- Closes #28