### PR TITLE
US-14: Endpoints CRUD projets PO

### DIFF
--- a/JiraVision/.env.example
+++ b/JiraVision/.env.example
@@ -4,7 +4,7 @@
 ATLASSIAN_CLIENT_ID=
 ATLASSIAN_CLIENT_SECRET=
 ATLASSIAN_REDIRECT_URI=http://localhost:8000/oauth/callback
-ATLASSIAN_SCOPES=read:jira-work
+ATLASSIAN_SCOPES=read:jira-work read:jira-user
 
 # Cookie/session signing (générer une valeur longue et aléatoire)
 APP_SECRET_KEY=

--- a/JiraVision/app/app/main.py
+++ b/JiraVision/app/app/main.py
@@ -12,6 +12,7 @@ from app.routes.auth_ui import router as auth_ui_router
 from app.routes.jira import router as jira_router
 from app.routes.ai import router as ai_router
 from app.routes.ui import router as ui_router  # version "choix 2" => prefix="/ui"
+from app.routes.po_projects import router as po_projects_router
 from app.routes.debug import router as debug_router
 from fastapi.responses import RedirectResponse
 from prometheus_client import (
@@ -103,6 +104,9 @@ def create_app() -> FastAPI:
     enable_poc = _env_flag("ENABLE_POC_UI", default=True)
     if enable_poc:
         app.include_router(ui_router)
+
+    # PO projects endpoints
+    app.include_router(po_projects_router)
 
     # Debug endpoints : dev only
     enable_debug = _env_flag("ENABLE_DEBUG_ROUTES", default=False)

--- a/JiraVision/app/app/routes/po_projects.py
+++ b/JiraVision/app/app/routes/po_projects.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Optional, List
+
+import httpx
+from fastapi import APIRouter, HTTPException, Request, Response
+from pydantic import BaseModel, Field
+
+from app.auth.session_store import ensure_session
+from app.core.redis import get_session
+from app.core import po_project_store
+from app.core import po_project_sync
+
+router = APIRouter(prefix="/po/projects", tags=["po-projects"])
+
+
+class ProjectAddRequest(BaseModel):
+    project_key: str = Field(..., min_length=1)
+    project_name: str = Field(..., min_length=1)
+    cloud_id: Optional[str] = None
+    source: str = "manual"
+    # Permet d'ajouter un projet inactif depuis la liste dédiée
+    is_active: Optional[bool] = True
+    inactive_at: Optional[int] = None
+
+
+class ProjectMaskRequest(BaseModel):
+    mask_type: str
+    cloud_id: Optional[str] = None
+
+
+class RefreshRequest(BaseModel):
+    # En refresh manuel, on peut réinitialiser les masquages définitifs
+    reset_definitif: bool = True
+
+
+def _ensure_session(request: Request, response: Response) -> Dict[str, Any]:
+    sid = ensure_session(request, response)
+    session = get_session(sid) or {}
+    # Jira account id est injecté au login OAuth (US-12)
+    if not session.get("jira_account_id"):
+        raise HTTPException(401, "Connecte-toi d'abord via Login Atlassian")
+    return session
+
+
+def _split_active_inactive(projects: List[Dict[str, Any]]) -> Dict[str, List[Dict[str, Any]]]:
+    active: List[Dict[str, Any]] = []
+    inactive: List[Dict[str, Any]] = []
+    for p in projects:
+        if p.get("is_active") is False:
+            inactive.append(p)
+        else:
+            active.append(p)
+    return {"projects": active, "inactive_projects": inactive}
+
+
+@router.get("")
+async def list_projects(request: Request, response: Response) -> Dict[str, Any]:
+    session = _ensure_session(request, response)
+    jira_account_id = session["jira_account_id"]
+
+    projects = po_project_store.list_projects_for_user(jira_account_id)
+    split = _split_active_inactive(projects)
+    user = po_project_store.get_user(jira_account_id) or {}
+
+    return {
+        **split,
+        "last_synced_at": user.get("last_synced_at"),
+    }
+
+
+@router.post("")
+async def add_project(
+    request: Request,
+    response: Response,
+    payload: ProjectAddRequest,
+) -> Dict[str, Any]:
+    session = _ensure_session(request, response)
+    jira_account_id = session["jira_account_id"]
+
+    try:
+        project = po_project_store.upsert_project_for_user(
+            jira_account_id,
+            project_key=payload.project_key,
+            project_name=payload.project_name,
+            source=payload.source,
+            cloud_id=payload.cloud_id,
+            is_active=payload.is_active,
+            inactive_at=payload.inactive_at,
+        )
+    except ValueError as exc:
+        raise HTTPException(400, str(exc)) from exc
+
+    return {"project": project}
+
+
+@router.delete("/{project_key}")
+async def delete_project(
+    project_key: str,
+    request: Request,
+    response: Response,
+    payload: ProjectMaskRequest,
+) -> Dict[str, Any]:
+    session = _ensure_session(request, response)
+    jira_account_id = session["jira_account_id"]
+
+    try:
+        project = po_project_store.set_project_mask(
+            jira_account_id,
+            project_key=project_key,
+            cloud_id=payload.cloud_id,
+            mask_type=payload.mask_type,
+        )
+    except ValueError as exc:
+        raise HTTPException(400, str(exc)) from exc
+    except KeyError as exc:
+        raise HTTPException(404, str(exc)) from exc
+
+    return {"project": project}
+
+
+@router.post("/refresh")
+async def refresh_projects(
+    request: Request,
+    response: Response,
+    payload: RefreshRequest,
+) -> Dict[str, Any]:
+    session = _ensure_session(request, response)
+    jira_account_id = session["jira_account_id"]
+
+    try:
+        data = await po_project_sync.sync_projects_for_user(
+            jira_account_id,
+            session,
+            reset_definitif=payload.reset_definitif,
+        )
+    except PermissionError:
+        raise HTTPException(401, "Token expiré — reconnecte-toi via /login")
+    except httpx.HTTPStatusError as exc:
+        snippet = (exc.response.text or "")[:300].replace("\n", " ")
+        raise HTTPException(exc.response.status_code, f"Jira error: {snippet}")
+    except Exception:
+        raise HTTPException(502, "Erreur lors du refresh Jira")
+
+    return data

--- a/JiraVision/tests/epic_10/us_11/test_po_project_store.py
+++ b/JiraVision/tests/epic_10/us_11/test_po_project_store.py
@@ -160,3 +160,42 @@ def test_list_projects_sorted(monkeypatch):
 
     projects = store.list_projects_for_user("acct")
     assert [p["project_key"] for p in projects] == ["ALPHA", "BETA"]
+
+
+def test_load_json_invalid_and_non_dict(monkeypatch):
+    # invalid JSON -> None
+    monkeypatch.setattr(store, "_get_raw", lambda _k: "not-json")
+    assert store._load_json("k") is None
+
+    # valid JSON but not a dict -> None
+    monkeypatch.setattr(store, "_get_raw", lambda _k: "[]")
+    assert store._load_json("k") is None
+
+
+def test_get_project_for_user(monkeypatch):
+    _force_local_store(monkeypatch)
+
+    store.upsert_project_for_user(
+        "acct",
+        project_key="PROJ",
+        project_name="Projet",
+        source="jira",
+        cloud_id="c1",
+        now=10,
+    )
+
+    found = store.get_project_for_user("acct", project_key="PROJ", cloud_id="c1")
+    assert found is not None
+    assert found["project_key"] == "PROJ"
+
+
+def test_set_project_mask_invalid(monkeypatch):
+    _force_local_store(monkeypatch)
+
+    with pytest.raises(ValueError):
+        store.set_project_mask(
+            "acct",
+            project_key="PROJ",
+            cloud_id="c1",
+            mask_type="bad",
+        )

--- a/JiraVision/tests/epic_10/us_13/test_po_project_sync.py
+++ b/JiraVision/tests/epic_10/us_13/test_po_project_sync.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import Any, Dict, List
 
+import httpx
+
 import pytest
 
 from app.core import po_project_store
@@ -100,3 +102,185 @@ async def test_sync_status_and_mask(monkeypatch):
 
     assert active["B"]["mask_type"] == "definitif"
     assert active["B"]["masked_at"] == 123
+
+
+@pytest.mark.asyncio
+async def test_sync_reset_definitif(monkeypatch):
+    monkeypatch.setattr(po_project_sync, "JiraClient", FakeJiraClient)
+
+    po_project_store.upsert_project_for_user(
+        "u1",
+        project_key="B",
+        project_name="Beta",
+        source="jira",
+        cloud_id="c1",
+        mask_type="definitif",
+        masked_at=123,
+    )
+
+    session = {
+        "tokens_by_cloud": {"c1": {"access_token": "tok1"}},
+        "cloud_ids": ["c1"],
+    }
+
+    result = await po_project_sync.sync_projects_for_user(
+        "u1",
+        session,
+        reset_definitif=True,
+    )
+    active = {p["project_key"]: p for p in result["projects"]}
+
+    assert active["B"]["mask_type"] == "none"
+
+
+@pytest.mark.asyncio
+async def test_sync_returns_empty_when_missing_inputs():
+    out = await po_project_sync.sync_projects_for_user("", {})
+    assert out == {"projects": [], "inactive_projects": []}
+
+
+@pytest.mark.asyncio
+async def test_sync_skips_cloud_without_token(monkeypatch):
+    monkeypatch.setattr(po_project_sync, "JiraClient", FakeJiraClient)
+
+    session = {
+        "tokens_by_cloud": {"c1": {}},
+        "cloud_ids": ["c1"],
+    }
+
+    out = await po_project_sync.sync_projects_for_user("u1", session)
+    assert out == {"projects": [], "inactive_projects": []}
+
+
+@pytest.mark.asyncio
+async def test_sync_epic_check_http_error(monkeypatch):
+    class EpicErrorClient(FakeJiraClient):
+        async def search_jql(self, jql: str, max_results: int = 20, next_page_token: str | None = None):
+            if "type = Epic" in jql:
+                req = httpx.Request("GET", "http://x")
+                resp = httpx.Response(400, request=req, content=b"bad")
+                raise httpx.HTTPStatusError("err", request=req, response=resp)
+            return await super().search_jql(jql, max_results=max_results, next_page_token=next_page_token)
+
+    monkeypatch.setattr(po_project_sync, "JiraClient", EpicErrorClient)
+
+    session = {
+        "tokens_by_cloud": {"c1": {"access_token": "tok1"}},
+        "cloud_ids": ["c1"],
+    }
+
+    result = await po_project_sync.sync_projects_for_user("u1", session)
+    active = {p["project_key"]: p for p in result["projects"]}
+    # Epic check error => has_epic=True
+    assert "A" in active
+
+
+@pytest.mark.asyncio
+async def test_sync_handles_permission_and_http_errors(monkeypatch):
+    class ErrorClient(FakeJiraClient):
+        async def search_jql(self, jql: str, max_results: int = 20, next_page_token: str | None = None):
+            if "reporter" in jql:
+                raise PermissionError()
+            return await super().search_jql(jql, max_results=max_results, next_page_token=next_page_token)
+
+    class HttpErrorClient(FakeJiraClient):
+        async def search_jql(self, jql: str, max_results: int = 20, next_page_token: str | None = None):
+            if "reporter" in jql:
+                req = httpx.Request("GET", "http://x")
+                resp = httpx.Response(400, request=req, content=b"bad")
+                raise httpx.HTTPStatusError("err", request=req, response=resp)
+            return await super().search_jql(jql, max_results=max_results, next_page_token=next_page_token)
+
+    session = {
+        "tokens_by_cloud": {"c1": {"access_token": "tok1"}},
+        "cloud_ids": ["c1"],
+    }
+
+    monkeypatch.setattr(po_project_sync, "JiraClient", ErrorClient)
+    out = await po_project_sync.sync_projects_for_user("u1", session)
+    assert out == {"projects": [], "inactive_projects": []}
+
+    monkeypatch.setattr(po_project_sync, "JiraClient", HttpErrorClient)
+    out = await po_project_sync.sync_projects_for_user("u1", session)
+    assert out == {"projects": [], "inactive_projects": []}
+
+
+@pytest.mark.asyncio
+async def test_sync_marks_previous_jira_projects_inactive(monkeypatch):
+    monkeypatch.setattr(po_project_sync, "JiraClient", FakeJiraClient)
+
+    po_project_store.upsert_project_for_user(
+        "u1",
+        project_key="Z",
+        project_name="Zulu",
+        source="jira",
+        cloud_id="c1",
+        mask_type="temporaire",
+    )
+    po_project_store.upsert_project_for_user(
+        "u1",
+        project_key="M",
+        project_name="Manual",
+        source="manual",
+        cloud_id="c1",
+    )
+
+    class NoIssuesClient(FakeJiraClient):
+        async def search_jql(self, jql: str, max_results: int = 20, next_page_token: str | None = None):
+            if "reporter" in jql:
+                return {"issues": []}
+            return {"issues": []}
+
+    monkeypatch.setattr(po_project_sync, "JiraClient", NoIssuesClient)
+
+    session = {
+        "tokens_by_cloud": {"c1": {"access_token": "tok1"}},
+        "cloud_ids": ["c1"],
+    }
+
+    result = await po_project_sync.sync_projects_for_user("u1", session)
+    inactive = {p["project_key"]: p for p in result["inactive_projects"]}
+    assert inactive["Z"]["is_active"] is False
+    # manual project should be ignored
+    assert "M" not in inactive
+
+
+@pytest.mark.asyncio
+async def test_sync_inactive_resets_definitif_when_manual_refresh(monkeypatch):
+    class NoIssuesClient(FakeJiraClient):
+        async def search_jql(self, jql: str, max_results: int = 20, next_page_token: str | None = None):
+            return {"issues": []}
+
+    monkeypatch.setattr(po_project_sync, "JiraClient", NoIssuesClient)
+
+    po_project_store.upsert_project_for_user(
+        "u1",
+        project_key="D",
+        project_name="Delta",
+        source="jira",
+        cloud_id="c1",
+        mask_type="definitif",
+        masked_at=123,
+    )
+    po_project_store.upsert_project_for_user(
+        "u1",
+        project_key="N",
+        project_name="None",
+        source="jira",
+        cloud_id="c1",
+        mask_type="none",
+    )
+
+    session = {
+        "tokens_by_cloud": {"c1": {"access_token": "tok1"}},
+        "cloud_ids": ["c1"],
+    }
+
+    result = await po_project_sync.sync_projects_for_user(
+        "u1",
+        session,
+        reset_definitif=True,
+    )
+    inactive = {p["project_key"]: p for p in result["inactive_projects"]}
+    assert inactive["D"]["mask_type"] == "none"
+    assert inactive["N"]["mask_type"] == "none"

--- a/JiraVision/tests/epic_10/us_14/test_routes_po_projects.py
+++ b/JiraVision/tests/epic_10/us_14/test_routes_po_projects.py
@@ -1,0 +1,165 @@
+import httpx
+
+from fastapi.testclient import TestClient
+
+from app.main import create_app
+
+app = create_app()
+client = TestClient(app)
+
+
+def _mock_session():
+    return {"jira_account_id": "acct"}
+
+
+def test_list_projects_splits_active_inactive(monkeypatch):
+    monkeypatch.setattr("app.routes.po_projects.ensure_session", lambda req, resp: "sid")
+    monkeypatch.setattr("app.routes.po_projects.get_session", lambda sid: _mock_session())
+
+    monkeypatch.setattr(
+        "app.routes.po_projects.po_project_store.list_projects_for_user",
+        lambda jid: [
+            {"project_key": "A", "is_active": False},
+            {"project_key": "B", "is_active": True},
+            {"project_key": "C"},
+        ],
+    )
+    monkeypatch.setattr(
+        "app.routes.po_projects.po_project_store.get_user",
+        lambda jid: {"last_synced_at": 123},
+    )
+
+    r = client.get("/po/projects")
+    assert r.status_code == 200
+    data = r.json()
+    assert {p["project_key"] for p in data["projects"]} == {"B", "C"}
+    assert {p["project_key"] for p in data["inactive_projects"]} == {"A"}
+    assert data["last_synced_at"] == 123
+
+
+def test_list_projects_requires_login(monkeypatch):
+    monkeypatch.setattr("app.routes.po_projects.ensure_session", lambda req, resp: "sid")
+    monkeypatch.setattr("app.routes.po_projects.get_session", lambda sid: {})
+
+    r = client.get("/po/projects")
+    assert r.status_code == 401
+
+
+def test_add_project_invalid_source(monkeypatch):
+    monkeypatch.setattr("app.routes.po_projects.ensure_session", lambda req, resp: "sid")
+    monkeypatch.setattr("app.routes.po_projects.get_session", lambda sid: _mock_session())
+
+    def _boom(*_a, **_k):
+        raise ValueError("Invalid source: bad")
+
+    monkeypatch.setattr("app.routes.po_projects.po_project_store.upsert_project_for_user", _boom)
+
+    r = client.post(
+        "/po/projects",
+        json={"project_key": "P", "project_name": "Proj", "source": "bad"},
+    )
+    assert r.status_code == 400
+
+
+def test_add_project_ok(monkeypatch):
+    monkeypatch.setattr("app.routes.po_projects.ensure_session", lambda req, resp: "sid")
+    monkeypatch.setattr("app.routes.po_projects.get_session", lambda sid: _mock_session())
+
+    monkeypatch.setattr(
+        "app.routes.po_projects.po_project_store.upsert_project_for_user",
+        lambda *a, **k: {"project_key": "P", "source": "manual"},
+    )
+
+    r = client.post(
+        "/po/projects",
+        json={"project_key": "P", "project_name": "Proj"},
+    )
+    assert r.status_code == 200
+    assert r.json()["project"]["project_key"] == "P"
+
+
+def test_delete_project_mask_errors(monkeypatch):
+    monkeypatch.setattr("app.routes.po_projects.ensure_session", lambda req, resp: "sid")
+    monkeypatch.setattr("app.routes.po_projects.get_session", lambda sid: _mock_session())
+
+    def _missing(*_a, **_k):
+        raise KeyError("Project not found")
+
+    monkeypatch.setattr("app.routes.po_projects.po_project_store.set_project_mask", _missing)
+
+    r = client.request(
+        "DELETE",
+        "/po/projects/PRJ",
+        json={"mask_type": "temporaire"},
+    )
+    assert r.status_code == 404
+
+
+def test_delete_project_mask_invalid(monkeypatch):
+    monkeypatch.setattr("app.routes.po_projects.ensure_session", lambda req, resp: "sid")
+    monkeypatch.setattr("app.routes.po_projects.get_session", lambda sid: _mock_session())
+
+    def _invalid(*_a, **_k):
+        raise ValueError("Invalid mask_type")
+
+    monkeypatch.setattr("app.routes.po_projects.po_project_store.set_project_mask", _invalid)
+
+    r = client.request(
+        "DELETE",
+        "/po/projects/PRJ",
+        json={"mask_type": "bad"},
+    )
+    assert r.status_code == 400
+
+
+def test_delete_project_mask_ok(monkeypatch):
+    monkeypatch.setattr("app.routes.po_projects.ensure_session", lambda req, resp: "sid")
+    monkeypatch.setattr("app.routes.po_projects.get_session", lambda sid: _mock_session())
+
+    monkeypatch.setattr(
+        "app.routes.po_projects.po_project_store.set_project_mask",
+        lambda *a, **k: {"project_key": "PRJ", "mask_type": "temporaire"},
+    )
+
+    r = client.request(
+        "DELETE",
+        "/po/projects/PRJ",
+        json={"mask_type": "temporaire"},
+    )
+    assert r.status_code == 200
+
+
+def test_refresh_projects_success_and_errors(monkeypatch):
+    monkeypatch.setattr("app.routes.po_projects.ensure_session", lambda req, resp: "sid")
+    monkeypatch.setattr("app.routes.po_projects.get_session", lambda sid: _mock_session())
+
+    async def _ok(*_a, **_k):
+        return {"projects": [], "inactive_projects": []}
+
+    monkeypatch.setattr("app.routes.po_projects.po_project_sync.sync_projects_for_user", _ok)
+
+    r = client.post("/po/projects/refresh", json={"reset_definitif": True})
+    assert r.status_code == 200
+
+    async def _perm(*_a, **_k):
+        raise PermissionError()
+
+    monkeypatch.setattr("app.routes.po_projects.po_project_sync.sync_projects_for_user", _perm)
+    r = client.post("/po/projects/refresh", json={"reset_definitif": True})
+    assert r.status_code == 401
+
+    async def _http_err(*_a, **_k):
+        req = httpx.Request("GET", "http://x")
+        resp = httpx.Response(400, request=req, content=b"bad")
+        raise httpx.HTTPStatusError("err", request=req, response=resp)
+
+    monkeypatch.setattr("app.routes.po_projects.po_project_sync.sync_projects_for_user", _http_err)
+    r = client.post("/po/projects/refresh", json={"reset_definitif": True})
+    assert r.status_code == 400
+
+    async def _boom(*_a, **_k):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr("app.routes.po_projects.po_project_sync.sync_projects_for_user", _boom)
+    r = client.post("/po/projects/refresh", json={"reset_definitif": True})
+    assert r.status_code == 502

--- a/docs/epics/epic-10/us-13/tests-report.md
+++ b/docs/epics/epic-10/us-13/tests-report.md
@@ -1,7 +1,7 @@
 # EPIC-10 / US-13 — Tests report
 
 ## Tests exécutés
-- pytest tests/epic_10/us_13/test_po_project_sync.py -q
+- pytest JiraVision/tests/epic_10/us_13/test_po_project_sync.py -q
 
 ## Résultats
-- OK (2 passed)
+- OK (9 passed)

--- a/docs/epics/epic-10/us-14/technical-design.md
+++ b/docs/epics/epic-10/us-14/technical-design.md
@@ -1,0 +1,22 @@
+# EPIC-10 / US-14 — Conception technique
+
+## Objectif
+Exposer des endpoints pour lister, ajouter, masquer et rafraîchir les projets PO.
+
+## Endpoints
+- `GET /po/projects` : retourne `projects`, `inactive_projects`, `last_synced_at`.
+- `POST /po/projects` : ajout manuel (y compris inactifs) via `source=manual`.
+- `DELETE /po/projects/{project_key}` : masquage avec `mask_type` (temporaire/définitif).
+- `POST /po/projects/refresh` : refresh Jira manuel, avec option `reset_definitif`.
+
+## Règles clés
+- Auth via session (`jira_account_id` requis).
+- Masquage temporaire reset au refresh.
+- Masquage définitif reset uniquement si `reset_definitif=true`.
+- Les projets inactifs peuvent être ajoutés manuellement avec `is_active=false`.
+
+## Erreurs
+- 401 si session invalide.
+- 400 si `source` ou `mask_type` invalide.
+- 404 si projet à masquer introuvable.
+- 4xx Jira propagé lors du refresh.

--- a/docs/epics/epic-10/us-14/tests-report.md
+++ b/docs/epics/epic-10/us-14/tests-report.md
@@ -1,0 +1,11 @@
+# EPIC-10 / US-14 — Rapport de tests
+
+## Tests exécutés
+- pytest JiraVision/tests/epic_10/us_13/test_po_project_sync.py -q
+- pytest JiraVision/tests/epic_10/us_14/test_routes_po_projects.py -q
+- pytest JiraVision/tests --cov=app --cov-report=term-missing
+
+## Résultats
+- OK (9 passed) pour `us_13` (inclut reset_definitif)
+- OK (8 passed) pour `us_14`
+- OK (213 passed), couverture 100%


### PR DESCRIPTION
## Résumé
- Ajout des endpoints /po/projects (list, add, delete, refresh)
- Support du reset du masquage définitif lors d’un refresh manuel
- Tests unitaires/route + couverture 100%
- Documentation tests + conception US-14

## Tests
- pytest JiraVision/tests --cov=app --cov-report=term-missing

## Références
- US #14
